### PR TITLE
Add HPGrid 1.0.0 Module

### DIFF
--- a/manifests/Manlaan/HPGrid/1.0.0.json
+++ b/manifests/Manlaan/HPGrid/1.0.0.json
@@ -9,11 +9,11 @@
             "username": "manlaan.8921"
         }
     ],
-    "description": "Displays grid over HP bar\n\nOriginal HPGrid file from QuitarHero's Marker Pack https://github.com/QuitarHero/Heros-Marker-Pack",
+    "description": "Displays grid over HP bar\n\nOriginal HPGrid.xml file from QuitarHero's Marker Pack https://github.com/QuitarHero/Heros-Marker-Pack",
     "dependencies": {
         "bh.blishhud": ">=0.7.0"
     },
     "url": "https://github.com/manlaan/BlishHud-HPGrid",
     "location": "https://github.com/manlaan/BlishHud-HPGrid/releases/download/1.0.0/HPGrid.bhm",
-    "hash": "6911F37587F61F4C76FB05EF903E0B960D38A5E7148219BCF76399D17AA5B25A"
+    "hash": "E2084415F6BC36EC163694BE261D11F5AA8A622AEB61800C1B65AACFBEDE1A69"
 }

--- a/manifests/Manlaan/HPGrid/1.0.0.json
+++ b/manifests/Manlaan/HPGrid/1.0.0.json
@@ -1,0 +1,19 @@
+{
+    "manifest_version": "1",
+    "name": "HP Grids",
+    "namespace": "HPGrid",
+    "version": "1.0.0",
+    "contributors": [
+        {
+            "name": "Manlaan",
+            "username": "manlaan.8921"
+        }
+    ],
+    "description": "Displays grid over HP bar\n\nOriginal HPGrid file from QuitarHero's Marker Pack https://github.com/QuitarHero/Heros-Marker-Pack",
+    "dependencies": {
+        "bh.blishhud": ">=0.7.0"
+    },
+    "url": "https://github.com/manlaan/BlishHud-HPGrid",
+    "location": "https://github.com/manlaan/BlishHud-HPGrid/releases/download/1.0.0/HPGrid.bhm",
+    "hash": "6911F37587F61F4C76FB05EF903E0B960D38A5E7148219BCF76399D17AA5B25A"
+}


### PR DESCRIPTION
New Module, HPGrid.   Shows lines on HP bar for notable events, similar to how Taco does, with added description of event.   