### PR TITLE
DistanceRings 1.0.3

### DIFF
--- a/manifests/Manlaan/DistanceRings/1.0.3.json
+++ b/manifests/Manlaan/DistanceRings/1.0.3.json
@@ -1,0 +1,19 @@
+{
+    "manifest_version": "1",
+    "name": "Distance Rings",
+    "namespace": "DistanceRings",
+    "version": "1.0.3",
+    "contributors": [
+        {
+            "name": "Manlaan",
+            "username": "manlaan.8921"
+        }
+    ],
+    "description": "Display Distance Rings",
+    "dependencies": {
+        "bh.blishhud": ">=0.10.0"
+    },
+    "url": "https://github.com/manlaan/Blishhud-DistanceRings",
+    "location": "https://github.com/manlaan/Blishhud-DistanceRings/releases/download/1.0.3/DistanceRings.bhm",
+    "hash": "E2B85DCBCC30338851628FB722CF167B57B8E13E988F305FA477C11DDD1A0ADD"
+}


### PR DESCRIPTION
Support for Blish 0.10.0+
Does not support 0.8.0-

Not sure if/when you want to push this live, but here it is when you're ready with Blish.  It does seem to work great with your current 0.9.0 (and much smoother).   