### PR TITLE
Add Stream Out v0.1.3

### DIFF
--- a/manifests/Nekres/Stream_Out_Module/0.1.3.json
+++ b/manifests/Nekres/Stream_Out_Module/0.1.3.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "1",
-  "name": "Stream Out Module",
-  "namespace": "Stream_Out_Module",
+  "name": "Stream Out",
+  "namespace": "Nekres.Stream_Out_Module",
   "version": "0.1.3",
   "contributors": [
     {
@@ -15,5 +15,5 @@
   },
   "url": "https://github.com/agaertner/Blish-HUD-Modules",
   "location": "https://github.com/agaertner/Blish-HUD-Modules/releases/download/18%2F09%2F2021/Stream.Out.bhm",
-  "hash": "F304EF4633597C95E0AB7F3F8B113EDA2C0AA0BB385DD62B967AD02D7937639A"
+  "hash": "43589B967C9334F3EA8E7C89D4FBF685C35EC572A3D62EC19A57B28FA85A5825"
 }

--- a/manifests/Stream_Out_Module/0.1.3.json
+++ b/manifests/Stream_Out_Module/0.1.3.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": "1",
+  "name": "Stream Out Module",
+  "namespace": "Stream_Out_Module",
+  "version": "0.1.3",
+  "contributors": [
+    {
+      "username": "Nekres.1038",
+      "name": "Nekres"
+    }
+  ],
+  "description": "Outputs current game information so that it can be used as a scene component source in broadcasting software which monitor specified output for changes.\n\nThe output will be generated in \"<Path-To-Your-Blish-HUD-Settings-Folder>\\stream_out\\\"\n(eg. \"..\\Documents\\Guild Wars 2\\addons\\blishhud\\stream_out\\\").",
+  "dependencies": {
+    "bh.blishhud": ">=0.10.0"
+  },
+  "url": "https://github.com/agaertner/Blish-HUD-Modules",
+  "location": "https://github.com/agaertner/Blish-HUD-Modules/releases/download/18%2F09%2F2021/Stream.Out.bhm",
+  "hash": "F304EF4633597C95E0AB7F3F8B113EDA2C0AA0BB385DD62B967AD02D7937639A"
+}


### PR DESCRIPTION
Outputs current game information so that it can be used as a scene component source in broadcasting software.

[Source](https://github.com/agaertner/Blish-HUD-Modules/tree/master/Stream%20Out%20Module)