### PR TITLE
Pathing v0.13.8

### DIFF
--- a/manifests/bh/community/pathing/0.13.8.json
+++ b/manifests/bh/community/pathing/0.13.8.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": "1",
+  "name": "Pathing",
+  "namespace": "bh.community.pathing",
+  "version": "0.13.8",
+  "contributors": [
+    {
+      "name": "Freesnow",
+      "url": "https://github.com/dlamkins",
+      "username": "LandersXanders.1235"
+    }
+  ],
+  "description": "Display markers and trails in-game.  Supports both .zip and .taco format markers.\n\nCheck out our guide: https://blishhud.com/docs/markers/",
+  "dependencies": {
+    "bh.blishhud": ">=0.10.0"
+  },
+  "url": "https://github.com/Blish-HUD/Pathing",
+  "location": "https://github.com/blish-hud/Pathing/releases/download/v0.13.8/Pathing-v0.13.8.bhm",
+  "hash": "7F48E2AA4CD33EA8E50F8594EED86A0F484706A27CF860634BF743CC3552F39B"
+}


### PR DESCRIPTION
- Fixed a bug where the current map would load its markers twice at the same time now especially common in v0.11.1+ of Blish HUD which could crash the overlay.
- Made missing texture attribute warnings use the base64 encoded version of the GUID instead of the raw GUID string.
- The main module assemblies are now signed!