### PR TITLE
Add StreamOut v0.5.1

### DIFF
--- a/manifests/Nekres/Stream_Out/0.5.1.json
+++ b/manifests/Nekres/Stream_Out/0.5.1.json
@@ -5,15 +5,15 @@
   "version": "0.5.1",
   "contributors": [
     {
-      "name": "Nekres",
-      "username": "TypoTiger.8352"
+      "username": "TypoTiger.8352",
+      "name": "Nekres"
     }
   ],
-  "description": "Outputs current game information so that it can be used as a dynamic source in broadcasting software that has\nfile monitoring capabilities.\nA guild's Message of the Day can contain text enclosed in [public]text here[/public] to signal this module permission to export it.\nIf the [public] region is not found or set incorrectly the 'guild_motd.txt' will not contain any text.\nSimilarly, other exported text and image files will also be cleared to reflect specific toggles and changes (eg. not representing a guild will clear 'guild_emblem.png', not commanding a squad will clear commander_icon.png,\nand so on).",
+  "description": "Outputs current game information so that it can be used as a dynamic source in broadcasting software that has\nfile monitoring capabilities.\nA guild's Message of the Day can contain text enclosed in [public]text here[/public] to signal this module permission to export it.\nIf the [public] region is not found or set incorrectly the 'guild_motd.txt' will not contain any text.\nSimilarly, other exported text and image files will also be cleared to reflect specific toggles and changes (eg. not representing a guild will clear 'guild_emblem.png', not commanding a squad will clear 'commander_icon.png',\nand so on).",
   "dependencies": {
     "bh.blishhud": ">=0.11.1-ci.64"
   },
   "url": "https://github.com/agaertner/Blish-HUD-Modules-Releases",
   "location": "https://github.com/agaertner/Blish-HUD-Modules-Releases/releases/download/bh.blishhud%3E%3D0.11.1-ci.64/Stream.Out.v0.5.1.bhm",
-  "hash": "602E1755931BFCCD3B72A0CE67B2A15D71CD54603DF231C636C818B093209B85"
+  "hash": "9C09294A277C3888A4845C782B49CC732ACA80694D76D3138A51223FFB8F8E0D"
 }

--- a/manifests/Nekres/Stream_Out/0.5.1.json
+++ b/manifests/Nekres/Stream_Out/0.5.1.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": "1",
+  "name": "Stream Out",
+  "namespace": "Nekres.Stream_Out",
+  "version": "0.5.1",
+  "contributors": [
+    {
+      "name": "Nekres",
+      "username": "TypoTiger.8352"
+    }
+  ],
+  "description": "Outputs current game information so that it can be used as a dynamic source in broadcasting software that has\nfile monitoring capabilities.\nA guild's Message of the Day can contain text enclosed with [public]text here[/public] to signal this module permission to export the enclosed text.\nIf the [public] region is not found or set incorrectly the 'guild_motd.txt' will not contain any text'.\nSimilarly, other exported text and image files will also be cleared to reflect specific toggles and changes (eg. not representing a guild will clear 'guild_emblem.png', not commanding a squad will clear commander_icon.png,\nand so on).",
+  "dependencies": {
+    "bh.blishhud": ">=0.11.1-ci.64"
+  },
+  "url": "https://github.com/agaertner/Blish-HUD-Modules-Releases",
+  "location": "https://github.com/agaertner/Blish-HUD-Modules-Releases/releases/download/bh.blishhud%3E%3D0.11.1-ci.64/Stream.Out.v0.5.1.bhm",
+  "hash": "95A9EB7EC29E8181A7A085185893115612228C778A1334C0EB480AE999AB529F"
+}

--- a/manifests/Nekres/Stream_Out/0.5.1.json
+++ b/manifests/Nekres/Stream_Out/0.5.1.json
@@ -5,8 +5,8 @@
   "version": "0.5.1",
   "contributors": [
     {
-      "name": "Nekres",
-      "username": "TypoTiger.8352"
+      "username": "TypoTiger.8352",
+      "name": "Nekres"
     }
   ],
   "description": "Outputs current game information so that it can be used as a dynamic source in broadcasting software that has\nfile monitoring capabilities.\nA guild's Message of the Day can contain text enclosed with [public]text here[/public] to signal this module permission to export the enclosed text.\nIf the [public] region is not found or set incorrectly the 'guild_motd.txt' will not contain any text'.\nSimilarly, other exported text and image files will also be cleared to reflect specific toggles and changes (eg. not representing a guild will clear 'guild_emblem.png', not commanding a squad will clear commander_icon.png,\nand so on).",
@@ -15,5 +15,5 @@
   },
   "url": "https://github.com/agaertner/Blish-HUD-Modules-Releases",
   "location": "https://github.com/agaertner/Blish-HUD-Modules-Releases/releases/download/bh.blishhud%3E%3D0.11.1-ci.64/Stream.Out.v0.5.1.bhm",
-  "hash": "95A9EB7EC29E8181A7A085185893115612228C778A1334C0EB480AE999AB529F"
+  "hash": "111D8DB5F5C8604EADDBDECC484EF5FFAEB51B98C9E8F74206062EACF7692B57"
 }

--- a/manifests/Nekres/Stream_Out/0.5.1.json
+++ b/manifests/Nekres/Stream_Out/0.5.1.json
@@ -5,15 +5,15 @@
   "version": "0.5.1",
   "contributors": [
     {
-      "username": "TypoTiger.8352",
-      "name": "Nekres"
+      "name": "Nekres",
+      "username": "TypoTiger.8352"
     }
   ],
-  "description": "Outputs current game information so that it can be used as a dynamic source in broadcasting software that has\nfile monitoring capabilities.\nA guild's Message of the Day can contain text enclosed with [public]text here[/public] to signal this module permission to export the enclosed text.\nIf the [public] region is not found or set incorrectly the 'guild_motd.txt' will not contain any text'.\nSimilarly, other exported text and image files will also be cleared to reflect specific toggles and changes (eg. not representing a guild will clear 'guild_emblem.png', not commanding a squad will clear commander_icon.png,\nand so on).",
+  "description": "Outputs current game information so that it can be used as a dynamic source in broadcasting software that has\nfile monitoring capabilities.\nA guild's Message of the Day can contain text enclosed in [public]text here[/public] to signal this module permission to export it.\nIf the [public] region is not found or set incorrectly the 'guild_motd.txt' will not contain any text.\nSimilarly, other exported text and image files will also be cleared to reflect specific toggles and changes (eg. not representing a guild will clear 'guild_emblem.png', not commanding a squad will clear commander_icon.png,\nand so on).",
   "dependencies": {
     "bh.blishhud": ">=0.11.1-ci.64"
   },
   "url": "https://github.com/agaertner/Blish-HUD-Modules-Releases",
   "location": "https://github.com/agaertner/Blish-HUD-Modules-Releases/releases/download/bh.blishhud%3E%3D0.11.1-ci.64/Stream.Out.v0.5.1.bhm",
-  "hash": "111D8DB5F5C8604EADDBDECC484EF5FFAEB51B98C9E8F74206062EACF7692B57"
+  "hash": "602E1755931BFCCD3B72A0CE67B2A15D71CD54603DF231C636C818B093209B85"
 }


### PR DESCRIPTION
- Added support for current represented guild. Name, tag, emblem as well as a part of the *Message of the Day* (specified by enclosing a part with [public]text here[/public] in the in-game MotD itself) will be exported.
- Changed pvp_win_loss_ratio.txt to pvp_winrate.txt in percent.
- Added support for commander status exporting commander or - if set via setting - catmander icon.