### PR TITLE
CurrentTemplates v0.1.0

### DIFF
--- a/manifests/lk0001/CurrentTemplates/0.1.0.json
+++ b/manifests/lk0001/CurrentTemplates/0.1.0.json
@@ -5,7 +5,8 @@
   "version": "0.1.0",
   "contributors": [
     {
-      "name": "lk0001"
+      "name": "lk0001",
+      "username": "IllusoryDream.7648"
     }
   ],
   "description": "Displays active build and equipment template names.\nWARNING: The data is read from GW2 API, so it's not always up-to-date. When you change the active template, it may take up to 5 minutes before the change is visible in the API (and in this module).",

--- a/manifests/lk0001/CurrentTemplates/0.1.0.json
+++ b/manifests/lk0001/CurrentTemplates/0.1.0.json
@@ -1,36 +1,18 @@
 {
+  "manifest_version": "1",
   "name": "Current Templates",
-  "version": "0.1.0",
   "namespace": "lk0001.CurrentTemplates",
-  "package": "Blish HUD Current Templates.dll",
-  "manifest_version": 1,
-
-  "description": "Displays active build and equipment template names.\nWARNING: The data is read from GW2 API, so it's not always up-to-date. When you change the active template, it may take up to 5 minutes before the change is visible in the API (and as a result, in this module).",
+  "version": "0.1.0",
+  "contributors": [
+    {
+      "name": "lk0001"
+    }
+  ],
+  "description": "Displays active build and equipment template names.\nWARNING: The data is read from GW2 API, so it's not always up-to-date. When you change the active template, it may take up to 5 minutes before the change is visible in the API (and in this module).",
   "dependencies": {
     "bh.blishhud": ">=0.11.5"
   },
-  "url": "https://github.com/lk0001/Blish-HUD-Current-Templates",
-  "author": {
-    "name": "lk0001",
-    "username": "IllusoryDream.7648"
-  },
-  "enabled_without_gw2": false,
-  "api_permissions": {
-    "account": {
-      "optional": false,
-      "details": "Required to fetch characters."
-    },
-    "characters": {
-      "optional": false,
-      "details": "Required to fetch characters."
-    },
-    "inventories": {
-      "optional": false,
-      "details": "Required to check equipment templates."
-    },
-    "builds": {
-      "optional": false,
-      "details": "Required to check build templates."
-    }
-  }
+  "url": "https://github.com/lk0001/Blish_HUD_Current_Templates",
+  "location": "https://github.com/lk0001/Blish-HUD-Current-Templates/releases/download/v0.1.0/Blish.HUD.Current.Templates_0.1.0.bhm",
+  "hash": "124B9F3D894C5E734CDF9B31ED50EA6959D28ABB29E83DE76905F456A88BFEBF"
 }

--- a/manifests/lk0001/CurrentTemplates/0.1.0.json
+++ b/manifests/lk0001/CurrentTemplates/0.1.0.json
@@ -1,0 +1,36 @@
+{
+  "name": "Current Templates",
+  "version": "0.1.0",
+  "namespace": "lk0001.CurrentTemplates",
+  "package": "Blish HUD Current Templates.dll",
+  "manifest_version": 1,
+
+  "description": "Displays active build and equipment template names.\nWARNING: The data is read from GW2 API, so it's not always up-to-date. When you change the active template, it may take up to 5 minutes before the change is visible in the API (and as a result, in this module).",
+  "dependencies": {
+    "bh.blishhud": ">=0.11.5"
+  },
+  "url": "https://github.com/lk0001/Blish-HUD-Current-Templates",
+  "author": {
+    "name": "lk0001",
+    "username": "IllusoryDream.7648"
+  },
+  "enabled_without_gw2": false,
+  "api_permissions": {
+    "account": {
+      "optional": false,
+      "details": "Required to fetch characters."
+    },
+    "characters": {
+      "optional": false,
+      "details": "Required to fetch characters."
+    },
+    "inventories": {
+      "optional": false,
+      "details": "Required to check equipment templates."
+    },
+    "builds": {
+      "optional": false,
+      "details": "Required to check build templates."
+    }
+  }
+}

--- a/manifests/lk0001/CurrentTemplates/0.1.0.json
+++ b/manifests/lk0001/CurrentTemplates/0.1.0.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "bh.blishhud": ">=0.11.5"
   },
-  "url": "https://github.com/lk0001/Blish_HUD_Current_Templates",
+  "url": "https://github.com/lk0001/Blish-HUD-Current-Templates",
   "location": "https://github.com/lk0001/Blish-HUD-Current-Templates/releases/download/v0.1.0/Blish.HUD.Current.Templates_0.1.0.bhm",
   "hash": "124B9F3D894C5E734CDF9B31ED50EA6959D28ABB29E83DE76905F456A88BFEBF"
 }


### PR DESCRIPTION
#### Description
Simple module displaying your current build and equipment template names from GW2 API.

*Requires BlishHUD v0.11.5* (unreleased as of 12.02.2022)

#### Screenshots
(see top left corner, between icons and party menu)
![CTv0.1.0](https://user-images.githubusercontent.com/145405/153717114-8bb6e815-1fa7-41d9-8f11-c62456abc3ff.png)

#### Release
https://github.com/lk0001/Blish-HUD-Current-Templates/releases/tag/v0.1.0