### PR TITLE
CurrentTemplates v0.2.0

### DIFF
--- a/manifests/lk0001/CurrentTemplates/0.2.0.json
+++ b/manifests/lk0001/CurrentTemplates/0.2.0.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": "1",
+  "name": "Current Templates",
+  "namespace": "lk0001.CurrentTemplates",
+  "version": "0.2.0",
+  "contributors": [
+    {
+      "name": "lk0001",
+      "username": "IllusoryDream.7648"
+    }
+  ],
+  "description": "Displays active build and equipment template names.\nWARNING: The data is read from GW2 API, so it's not always up-to-date. When you change the active template, it may take up to 5 minutes before the change is visible in the API (and as a result, in this module).",
+  "dependencies": {
+    "bh.blishhud": ">=0.11.5"
+  },
+  "url": "https://github.com/lk0001/Blish-HUD-Current-Templates",
+  "location": "https://github.com/lk0001/Blish-HUD-Current-Templates/releases/download/v0.2.0/Blish.HUD.Current.Templates_0.2.0.bhm",
+  "hash": "679327422E74CAACE0D70448149F30293BF24D44CB59C79A10FBCF756892D180"
+}


### PR DESCRIPTION
#### Description
Adds BuildPad support: 
If user provides a path to BuildPad config file (autocompleted if it's in one of predefined locations), it'll use builds saved in BuildPad to display build name (utility skills are ignored, at least for now).

#### Screenshots
Without BuildPad integration (current behavior):
![bh-ct-1](https://user-images.githubusercontent.com/145405/155855681-4b70273a-195c-4dd8-b959-6d3a82545dfe.png)

With BuildPad integration, when current build is saved in BuildPad
![bh-ct-2](https://user-images.githubusercontent.com/145405/155855682-ea1dd094-bc55-4304-9d0d-64a80d04995b.png)

With BuildPad integration, when current build is not saved in BuildPad
![bh-ct-3](https://user-images.githubusercontent.com/145405/155855683-21c590cb-7a16-461b-bb66-68e07cb277ff.png)
