### PR TITLE
Mounts 1.2.15

### DIFF
--- a/manifests/Manlaan/Mounts/1.2.15.json
+++ b/manifests/Manlaan/Mounts/1.2.15.json
@@ -1,0 +1,23 @@
+{
+    "manifest_version": "1",
+    "name": "Mounts",
+    "namespace": "Manlaan.Mounts",
+    "version": "1.2.15",
+    "contributors": [
+        {
+            "name": "Manlaan",
+            "username": "manlaan.8921"
+        },
+        {
+            "name": "bennieboj",
+            "username": "bennieboj"
+        }
+    ],
+    "description": "Mount icons",
+    "dependencies": {
+        "bh.blishhud": ">=0.11.6"
+    },
+    "url": "https://github.com/manlaan/BlishHud-Mounts",
+    "location": "https://github.com/manlaan/BlishHud-Mounts/releases/download/1.2.15/Mounts.bhm",
+    "hash": "FD67A63E74CC1F82AED408C384EFC869B6660A4F2E34DA60214997F837E0A786"
+}


### PR DESCRIPTION
don't queue unmounting when in combat
undo BlockSequenceFromGw2 to make sure keybinds with only a primary key still go to chat
don't show radial when dragging the camera with the mouse, but use defaultMount if it is configured