### PR TITLE
Tyria Planner 0.9.5

### DIFF
--- a/manifests/com/tyriaplanner/hud/0.9.5.json
+++ b/manifests/com/tyriaplanner/hud/0.9.5.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": "1",
+  "name": "Tyria Planner",
+  "namespace": "com.tyriaplanner.hud",
+  "version": "0.9.5",
+  "contributors": [
+    {
+      "name": "Tyria Planner",
+      "username": "Sercanirik",
+      "url": "https://github.com/Sercanirik"
+    }
+  ],
+  "description": "In-game popups for upcoming signups and brand-new guild events scheduled on tyriaplanner.com.\n\nAdds a corner-icon menu, /sqjoin and copy-commander-name buttons, one-click check-in, and an officer / event-creator approval queue. Pulls a wider snapshot every 60 s while the menu is open and pushes reminder toasts ahead of check-in and event start. Server-sent events surface new guild events within seconds.\n\nThe addon exchanges your GW2 API key for a scoped 90-day bearer (addon:read addon:write) on first use. The bearer can read your upcoming events + guild events + the approval queue, and powers two user-initiated actions only: marking your own signup as 'checked in', and approving / rejecting pending signups in guilds where you are an officer/owner (or events you created). Revoke at any time from your Tyria Planner profile.\n\nSource and issues: https://github.com/Sercanirik/TyriaPlannerHud-Blish",
+  "dependencies": {
+    "bh.blishhud": ">=1.0.0"
+  },
+  "url": "https://github.com/Sercanirik/TyriaPlannerHud-Blish",
+  "location": "https://github.com/Sercanirik/TyriaPlannerHud-Blish/releases/download/v0.9.5/TyriaPlanner.Hud.bhm",
+  "hash": "DF24BDDC64DE9F08C84A36D1185A6271FD795F8A3566D7C4FB94BA9A840294D4"
+}


### PR DESCRIPTION
Submitting `Tyria Planner` (`com.tyriaplanner.hud`) v0.9.5.

## Module summary

In-game popups for upcoming signups and brand-new guild events scheduled on [tyriaplanner.com](https://tyriaplanner.com). The module adds a corner-icon menu, `/sqjoin` and copy-commander-name buttons, one-click check-in, and an officer / event-creator approval queue. A server-sent events stream keeps the in-game view in sync within seconds.

## Verification

- `.bhm` is built by GitHub Actions on the public source repo and attached to the v0.9.5 release: <https://github.com/Sercanirik/TyriaPlannerHud-Blish/releases/tag/v0.9.5>
- Source: <https://github.com/Sercanirik/TyriaPlannerHud-Blish> · MIT license
- SHA-256 of `TyriaPlanner.Hud.bhm`: `DF24BDDC64DE9F08C84A36D1185A6271FD795F8A3566D7C4FB94BA9A840294D4` (matches the value in the manifest)

## Manifest

Single file added: `manifests/com/tyriaplanner/hud/0.9.5.json`.

## Permissions / network

- HTTPS only · talks to `https://tyriaplanner.com/api/addon/*`
- Exchanges the user's GW2 API key for a scoped 90-day bearer on first use; the key is sent exactly once
- Bearer scopes: `addon:read` and `addon:write` · only powers user-initiated actions (mark own signup checked-in; approve/reject pending signups in guilds the user is officer/owner of, or events they created)

Happy to address any review feedback.